### PR TITLE
Missing tmp fail test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.flags.json
+/tmp

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
+const exec = require('child_process').exec;
 
 const expect = require('chai').expect;
 
@@ -29,5 +30,12 @@ describe('v8flags', function () {
     });
   });
 
+  it('should not fail with a missing $TMP dir on a Linux os', function (done) {
+    var cmd ="TMP=\"$(pwd)/tmp\" node -e \"require('v8flags')(function(err, flags){if(err) throw err; else console.log(flags.length);})\"";
+    exec(cmd, function (err, stdout, stderr) {
+      expect(err).to.be.null;
+      done();
+    });
+  });
 
 });

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ describe('v8flags', function () {
   });
 
   it('should not fail with a missing $TMP dir on a Linux os', function (done) {
-    var cmd ="TMP=\"$(pwd)/tmp\" node -e \"require('v8flags')(function(err, flags){if(err) throw err; else console.log(flags.length);})\"";
+    var cmd ="TMP=\"$(pwd)/tmp\" node -e \"require('./index.js')(function(err, flags){if(err) throw err; else console.log(flags.length);})\"";
     exec(cmd, function (err, stdout, stderr) {
       expect(err).to.be.null;
       done();


### PR DESCRIPTION
As requested, about #13 - the test fails on my linux box with:

```
  1) v8flags should not fail with a missing $TMP dir on a Linux os:
     Uncaught AssertionError: expected [Error: Command failed:
[eval]:1
require('./index.js')(function(err, flags){if(err) throw err; else console.log
                                                         ^
Error: ENOENT, open '/home/orlin/Dev/v8flags/tmp/3.14.5.9.flags.json'
] to be null
```

Maybe we should try to create the dir if it doesn't exist?
