### PR TITLE
harden v8flags for people with jacked up environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,36 +1,93 @@
+// this entire module is depressing.
+
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const execFile = require('child_process').execFile;
-
-const tmpfile = path.join(os.tmpdir(), process.versions.v8+'.flags.json');
+const env = process.env;
+const user = env.LOGNAME || env.USER || env.LNAME || env.USERNAME;
+const configfile = '.v8flags.'+process.versions.v8+'.'+user+'.json';
 const exclusions = ['--help'];
 
-module.exports = function (cb) {
-  try {
-    var flags = require(tmpfile);
-    process.nextTick(function(){
-      cb(null, flags);
+const failureMessage = [
+  'Unable to cache a config file for v8flags to a your home directory',
+  'or a temporary folder. To fix this problem, please correct your',
+  'environment by setting HOME=/path/to/home or TEMP=/path/to/temp.',
+  'NOTE: the user running this must be able to access provided path.',
+  'If all else fails, please open an issue here:',
+  'http://github.com/tkellen/js-v8flags'
+].join('\n');
+
+function fail (err) {
+  err.message += '\n\n' + failureMessage;
+  return err;
+}
+
+function openConfig (cb) {
+  var userHome = require('user-home');
+  var configpath = path.join(userHome || os.tmpdir(), configfile);
+  fs.open(configpath, 'a+', function (err, fd) {
+    if (err) {
+      return cb(fail(err));
+    }
+    return cb(null, fd);
+  });
+}
+
+function writeConfig (fd, cb) {
+  execFile(process.execPath, ['--v8-options'], function (execErr, result) {
+    var flags;
+    if (execErr) {
+      return cb(execErr);
+    }
+    flags = result.match(/\s\s--(\w+)/gm).map(function (match) {
+      return match.substring(2);
+    }).filter(function (name) {
+      return exclusions.indexOf(name) === -1;
     });
-  } catch (e) {
-    execFile(process.execPath, ['--v8-options'], function (execErr, result) {
-      var flags;
-      if (execErr) {
-        return cb(execErr);
-      }
-      flags = result.match(/\s\s--(\w+)/gm).map(function (match) {
-        return match.substring(2);
-      }).filter(function (name) {
-        return exclusions.indexOf(name) === -1;
-      });
-      fs.writeFile(tmpfile, JSON.stringify(flags), { encoding:'utf8' },
-        function (writeErr) {
-          if (writeErr) {
-            return cb(writeErr);
-          }
-          cb(null, flags);
+    var buf = new Buffer(JSON.stringify(flags));
+
+    fs.write(fd, buf, 0, buf.length, null, function (writeErr, bytesWritten, buffer) {
+      fs.close(fd, function (closeErr) {
+        var err = writeErr || closeErr;
+        if (err) {
+          return cb(fail(err));
         }
-      );
+        return cb(null, JSON.parse(buffer.toString()));
+      });
     });
-  }
+  });
+}
+
+function readConfig (fd, filesize, cb) {
+  var buf = new Buffer(filesize);
+  fs.read(fd, buf, 0, filesize, 0, function (readErr, bytesRead, buffer) {
+    fs.close(fd, function (closeErr) {
+      var err = readErr || closeErr;
+      if (err) {
+        return cb(fail(err));
+      }
+      return cb(null, JSON.parse(buffer.toString()));
+    });
+  });
+}
+
+module.exports = function (cb) {
+  openConfig(function (err, fd) {
+    if (err) {
+      return cb(fail(err));
+    }
+    fs.fstat(fd, function (statErr, stats) {
+      var filesize = stats.size;
+      if (statErr) {
+        return cb(fail(statErr));
+      }
+      if (filesize === 0) {
+        return writeConfig(fd, cb);
+      }
+      return readConfig(fd, filesize, cb);
+    });
+  });
 };
+
+module.exports.configfile = configfile;

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   "devDependencies": {
     "chai": "~1.9.1",
     "mocha": "~1.21.4"
+  },
+  "dependencies": {
+    "user-home": "^1.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -4,30 +4,48 @@ const path = require('path');
 
 const expect = require('chai').expect;
 
-const v8flags = require('./');
-
-const tmpfile = path.resolve(os.tmpdir(), process.versions.v8+'.flags.json');
+const env = process.env;
 
 describe('v8flags', function () {
 
-  after(function () {
-    fs.unlinkSync(tmpfile);
+  var v8flags;
+
+  beforeEach(function () {
+    delete require.cache[require.resolve('user-home')];
   });
 
-  it('should call back with the v8 flags for the running process', function (done) {
-    // if i could meaningfully test this, this libray wouldn't exist
+  it('should cache and call back with the v8 flags for the running process', function (done) {
+    var v8flags = require('./');
+    var configfile = path.resolve(require('user-home'), v8flags.configfile);
     v8flags(function (err, flags) {
       expect(flags).to.be.a('array');
-      done();
+      expect(fs.existsSync(configfile)).to.be.true;
+      fs.unlinkSync(configfile);
+      fs.writeFileSync(configfile, JSON.stringify({cached:true}));
+      v8flags(function (cacheErr, cachedFlags) {
+        expect(cachedFlags).to.deep.equal({cached:true});
+        fs.unlinkSync(configfile);
+        done();
+      });
     });
   });
 
-  it('should cache v8 flags after first run', function (done) {
+  it('should fall back to writing to a temp dir if user home can\'t be found', function (done) {
+    delete env.HOME;
+    delete env.USERPROFILE;
+    delete env.HOMEDRIVE;
+    delete env.HOMEPATH;
+    delete env.LOGNAME;
+    delete env.USER;
+    delete env.LNAME;
+    delete env.USERNAME;
+    var v8flags = require('./');
+    var configfile = path.resolve(os.tmpdir(), v8flags.configfile);
     v8flags(function (err, flags) {
-      expect(fs.existsSync(tmpfile)).to.be.true;
+      expect(fs.existsSync(configfile)).to.be.true;
+      fs.unlinkSync(configfile);
       done();
     });
   });
-
 
 });


### PR DESCRIPTION
would love some feedback on this mess if you have time @contra @phated @sindresorhus.

basically, this tries to deal with fucked up environments where a temp directory cannot be found using `os.tmpdir()`, which is (sadly) not all that uncommon. i hate this module.